### PR TITLE
Fix for Node.js 4

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,8 @@ const loading = (label, message) => print('loading', label, message)
 const command = command => chalk.blue(command)
 const link = url => chalk.blue(url)
 
-const error = (err, options = { exit: true, silent: false, label }) => {
+const error = (err, options) => {
+  if (!options) options = { exit: true, silent: false, label }
   print('error', options.label || 'ERROR', err)
   if (options.silent) process.exit(1)
   if (options.exit) throw new Error(err)


### PR DESCRIPTION
Node.js 4 is still supported by Node Foundation. Also many big companies still use it.

And PostCSS and many other projects use Node.js 4 in Travis CI.