### PR TITLE
Refactored the function parameter usage

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,9 +16,9 @@ const print = (message, label, type) => {
   )
 }
 
-const info = (label, message) => print('info', label, message)
-const warn = message => print('warn', 'WARN', message)
-const loading = (label, message) => print('loading', label, message)
+const info = (message, label = 'INFO') => print(message, label, 'info')
+const warn = (message, label = 'WARN') => print(message, label, 'warn')
+const loading = (message, label = 'LOADING') => print(message, label, 'loading')
 
 const command = command => chalk.blue(command)
 const link = url => chalk.blue(url)

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ const colorMap = {
   error: 'red'
 }
 
-const print = (type, label, message) => {
+const print = (message, label, type) => {
   const color = colorMap[type]
   console.log(
     chalk.inverse.bold[color](` ${label} `),

--- a/index.js
+++ b/index.js
@@ -20,8 +20,8 @@ const info = (message, label = 'INFO') => print(message, label, 'info')
 const warn = (message, label = 'WARN') => print(message, label, 'warn')
 const loading = (message, label = 'LOADING') => print(message, label, 'loading')
 
-const command = command => chalk.blue(command)
-const link = url => chalk.blue(url)
+const command = message => chalk.blue(message)
+const link = command
 
 const error = (err, options) => {
   const label = 'ERROR'

--- a/index.js
+++ b/index.js
@@ -23,12 +23,10 @@ const loading = (message, label = 'LOADING') => print(message, label, 'loading')
 const command = message => chalk.blue(message)
 const link = command
 
-const error = (err, options) => {
-  const label = 'ERROR'
-  if (!options) options = { exit: true, silent: false, label }
-  print('error', options.label || label, err)
+const error = (message, label = 'ERROR', options = { exit: true, silent: false }) => {
+  print(message, label, 'error')
   if (options.silent) process.exit(1)
-  if (options.exit) throw new Error(err)
+  if (options.exit) throw new Error(message)
 }
 
 module.exports = { info, loading, warn, error, command, link }


### PR DESCRIPTION
Hey @siddharthkp

I have made lot of changes and might break the existing tool usage... They are not adding any additional functionality, but improving on the existing code. 🙂 

* Created **default** parameter values for labels. 
* Standardized the order of parameters across the functions to `message`, 'label', 'type' / 'options'
* Erorr: Moved label and options to parameters and added defaults and maintained the same parameter order there as well. 
* Removed duplicate functions for command and link 
(in fact I would like to keep both functions and add underline for link)

I won't expect you to accept all the changes. Let me know if any of these are helpful. I can do a separate pr for the approved ones. Would like to hear your thought! 😄 
